### PR TITLE
Add hubot-cron to schedule announcements, such as the weekly meeting

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,5 +1,6 @@
 [
   "hubot-bugzilla",
+  "hubot-cron",
   "hubot-diagnostics",
   "hubot-github-repo-event-notifier2",
   "hubot-help",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "hubot": "^2.16.0",
     "hubot-bugzilla": "0.0.1",
+    "hubot-cron": ">= 0.1.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-github-repo-event-notifier2": ">= 0.0.0",
     "hubot-help": "^0.1.1",
@@ -14,7 +15,8 @@
     "hubot-hipchat": "~2.5.1-5",
     "hubot-irc": "^0.2.8",
     "hubot-redis-brain": "0.0.3",
-    "hubot-scripts": "^2.16.2"
+    "hubot-scripts": "^2.16.2",
+    "time": "^0.11.4"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
I have tested this locally and it seems to work well. Once this and PR #12 are merged we can configure the bot to announce our meeting every week at 11:45am Pacific time, which will resolve issue #5.

@davehunt r? 