### PR TITLE
Use node-cron to set up weekly meeting reminders

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,1 +1,4 @@
-["webqa"]
+[
+  "cron-jobs",
+  "webqa"
+]

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "author": "Mozilla Web QA <mozwebqa@mozilla.org>",
   "description": "IRC bot to help out in #mozwebqa on irc.mozilla.org",
   "dependencies": {
+    "cron": "^1.0.9",
     "hubot": "^2.16.0",
     "hubot-bugzilla": "0.0.1",
-    "hubot-cron": ">= 0.1.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-github-repo-event-notifier2": ">= 0.0.0",
     "hubot-help": "^0.1.1",
@@ -15,8 +15,7 @@
     "hubot-hipchat": "~2.5.1-5",
     "hubot-irc": "^0.2.8",
     "hubot-redis-brain": "0.0.3",
-    "hubot-scripts": "^2.16.2",
-    "time": "^0.11.4"
+    "hubot-scripts": "^2.16.2"
   },
   "engines": {
     "node": "0.10.x"

--- a/scripts/cron-jobs.coffee
+++ b/scripts/cron-jobs.coffee
@@ -1,0 +1,12 @@
+# Description:
+#   Sets up cron jobs for webqabot.
+#
+
+module.exports = (robot) ->
+
+  announceMeeting = () ->
+    robot.emit "announceMeeting", "in 15 minutes"
+
+  tz = "America/Los_Angeles"
+  cronJob = require("cron").CronJob
+  new cronJob("45 8 * * 4", announceMeeting, null, true, tz)

--- a/scripts/webqa.coffee
+++ b/scripts/webqa.coffee
@@ -4,21 +4,23 @@
 
 module.exports = (robot) ->
 
-  meeting = (res, time) ->
-    time = if time != "" then time else "at 9am Pacific every Thursday"
-    res.send "Come join us #{time} for our team meeting!"
-    res.send "Meeting notes are available at https://wiki.mozilla.org/QA/Execution/Web_Testing#Meeting_Notes"
-    vidyo res
+  room = if process.env.HUBOT_IRC_ROOMS then process.env.HUBOT_IRC_ROOMS.split ","[0] else "#mozwebqa"
 
-  vidyo = (res) ->
-    res.send "Our Vidyo room is WebQA (8824)"
-    res.send "Public link: https://v.mozilla.com/flex.html?roomdirect.html&key=Tc08xVjMQmaVscjhN5jlm7mDknY"
-    res.send "Joining by phone: https://wiki.mozilla.org/Teleconferencing#Dialing_In"
-    res.send "For information on Vidyo: https://wiki.mozilla.org/Vidyo"
+  meeting = (time) ->
+    time = if time != "" then time else "at 9am Pacific every Thursday"
+    robot.messageRoom room, "Come join us #{time} for our team meeting!"
+    robot.messageRoom room, "Meeting notes are available at https://wiki.mozilla.org/QA/Execution/Web_Testing#Meeting_Notes"
+    vidyo()
+
+  vidyo = () ->
+    robot.messageRoom room, "Our Vidyo room is WebQA (8824)"
+    robot.messageRoom room, "Public link: https://v.mozilla.com/flex.html?roomdirect.html&key=Tc08xVjMQmaVscjhN5jlm7mDknY"
+    robot.messageRoom room, "Joining by phone: https://wiki.mozilla.org/Teleconferencing#Dialing_In"
+    robot.messageRoom room, "For information on Vidyo: https://wiki.mozilla.org/Vidyo"
 
   # announce or provide details of our team meeting
   robot.respond /meeting\s*\b(.*)/i, (res) ->
-    meeting res, res.match[1]
+    meeting res.match[1]
 
   # provide details of our team mission
   robot.respond /mission/i, (res) ->
@@ -31,4 +33,7 @@ module.exports = (robot) ->
 
   # provide details of our vidyo room
   robot.respond /vidyo/i, (res) ->
-    vidyo res
+    vidyo()
+
+  robot.on "announceMeeting", (time) ->
+    meeting time


### PR DESCRIPTION
@davehunt This will set up the bot to make our meeting announcement 15 minutes before each meeting. You can test it locally by changing the crontab to be something like every minute to see if it works.

I also took the opportunity to standardize on single quotes over double quotes, while the codebase is still quite small.

r?
