### PR TITLE
Initial commit for issue #18. Added unit tests for the webqabot.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+ - "stable"
+# following is from: https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements
+env:
+ - CXX=g++-4.8
+addons:
+ apt:
+   sources:
+     - ubuntu-toolchain-r-test
+   packages:
+     - g++-4.8
+     

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # webqabot
 
 [![license](https://img.shields.io/badge/license-MPL%202.0-blue.svg)](https://github.com/mozilla/webqabot/blob/master/LICENSE)
+[![Build Status](https://travis-ci.org/mozilla/webqabot.svg?branch=master)](https://travis-ci.org/mozilla/webqabot)
 
 webqabot is a chat bot built on the [Hubot][hubot] framework for use in the [#mozwebqa IRC channel][mozwebqa].
 
@@ -31,6 +32,14 @@ Then you can interact with webqabot by typing `webqabot help`.
     webqabot help - Displays all of the help commands that webqabot knows about.
     webqabot ping - Reply with pong
     ...
+
+
+## Testing webqabot
+
+The unit tests can be run via the command line with the command:
+```
+npm test
+```
 
 ## Deploying to Heroku
 
@@ -71,6 +80,10 @@ want to make any changes or add any features, that is the best place to start.
 You may also want to check out the [Hubot Scripting Guide][scripting-docs].
 
 [scripting-docs]: https://hubot.github.com/docs/scripting/
+
+The responses the bot uses are located in the [`resources/responses.properties`](resources/responses.properties) file. 
+
+Unit tests for the bot are located in the [`tests/test_webqa.coffee`](tests/test_webqa.coffee) file.  The ```context 'hubot responding to events'``` is where you add tests that test if the bot responds to [events](https://hubot.github.com/docs/scripting/#events) created by another script (such as [`cron-jobs.coffee`](scripts/cron-jobs.coffee)).  The ```context 'hubot responding to user messages'``` is where you add tests that test if the bot responds to messages sent by a user.  If your test does not fall under those two categories then please create a new context and add your test there.
 
 ### external-scripts
 

--- a/package.json
+++ b/package.json
@@ -15,9 +15,20 @@
     "hubot-irc": "^0.2.8",
     "hubot-redis-brain": "0.0.3",
     "hubot-scripts": "^2.16.2",
-    "hubot-welcome": "0.0.3"
+    "hubot-welcome": "0.0.3",
+    "properties-reader": "^0.0.15"
   },
   "engines": {
-    "node": "0.10.x"
+    "node": ">=0.10.x",
+    "npm": ">= 1.1.x"
+  },
+  "devDependencies": {
+    "chai": "^3.4.1",
+    "hubot-test-helper": "^1.3.0",
+    "mocha": "^2.3.4",
+    "coffee-script": "^1.10.0"
+  },
+  "scripts": {
+    "test": "mocha --compilers coffee:coffee-script/register tests"
   }
 }

--- a/resources/responses.properties
+++ b/resources/responses.properties
@@ -1,0 +1,14 @@
+team = https://wiki.mozilla.org/QA/Execution/Web_Testing#Team_Members
+source = My details and code live at https://github.com/mozilla/webqabot/
+mission = Our mission is to provide data, services and tools to positively impact the quality of Mozilla websites. https://wiki.mozilla.org/QA/Execution/Web_Testing/Mission
+list1 = Email: mozwebqa@mozilla.org
+list2 = Subscribe: https://mail.mozilla.org/listinfo/mozwebqa/
+list3 = Archive: https://mail.mozilla.org/private/mozwebqa/
+vidyo1 = Our Vidyo room is WebQA (8824)
+vidyo2 = Public link: https://v.mozilla.com/flex.html?roomdirect.html&key=Tc08xVjMQmaVscjhN5jlm7mDknY
+vidyo3 = Joining by phone: https://wiki.mozilla.org/Teleconferencing#Dialing_In
+vidyo4 = For information on Vidyo: https://wiki.mozilla.org/Vidyo
+time1 = at 9am Pacific every Thursday
+time2 = Come join us %s for our team meeting!
+time3 = Meeting notes are available at https://wiki.mozilla.org/QA/Execution/Web_Testing#Meeting_Notes
+cronTime = in 15 minutes

--- a/scripts/cron-jobs.coffee
+++ b/scripts/cron-jobs.coffee
@@ -2,10 +2,13 @@
 #   Sets up cron jobs for webqabot.
 #
 
+PropertiesReader = require 'properties-reader'
+properties = PropertiesReader('resources/responses.properties')
+
 module.exports = (robot) ->
 
   announceMeeting = () ->
-    robot.emit "announceMeeting", "in 15 minutes"
+    robot.emit "announceMeeting", properties.get("cronTime")
 
   tz = "America/Los_Angeles"
   cronJob = require("cron").CronJob

--- a/scripts/webqa.coffee
+++ b/scripts/webqa.coffee
@@ -1,28 +1,29 @@
 # Description:
 #   Webqabot's internal behaviour
-#
-
+util = require 'util' 
+PropertiesReader = require 'properties-reader'
+properties = PropertiesReader('resources/responses.properties')
 module.exports = (robot) ->
 
   room = if process.env.HUBOT_IRC_ROOMS then process.env.HUBOT_IRC_ROOMS.split ","[0] else "#mozwebqa"
 
   meeting = (time) ->
-    time = if time != "" then time else "at 9am Pacific every Thursday"
-    robot.messageRoom room, "Come join us #{time} for our team meeting!"
-    robot.messageRoom room, "Meeting notes are available at https://wiki.mozilla.org/QA/Execution/Web_Testing#Meeting_Notes"
+    time = if time != "" then time else properties.get("time1")
+    robot.messageRoom room, util.format(properties.get("time2"), time)
+    robot.messageRoom room, properties.get("time3")
     vidyo()
 
   vidyo = () ->
-    robot.messageRoom room, "Our Vidyo room is WebQA (8824)"
-    robot.messageRoom room, "Public link: https://v.mozilla.com/flex.html?roomdirect.html&key=Tc08xVjMQmaVscjhN5jlm7mDknY"
-    robot.messageRoom room, "Joining by phone: https://wiki.mozilla.org/Teleconferencing#Dialing_In"
-    robot.messageRoom room, "For information on Vidyo: https://wiki.mozilla.org/Vidyo"
+    robot.messageRoom room, properties.get("vidyo1")
+    robot.messageRoom room, properties.get("vidyo2")
+    robot.messageRoom room, properties.get("vidyo3")
+    robot.messageRoom room, properties.get("vidyo4")
 
   # provide details about our mailing list
   robot.respond /list/i, (res) ->
-    res.send "Email: mozwebqa@mozilla.org"
-    res.send "Subscribe: https://mail.mozilla.org/listinfo/mozwebqa/"
-    res.send "Archive: https://mail.mozilla.org/private/mozwebqa/"
+    res.send properties.get("list1")
+    res.send properties.get("list2")
+    res.send properties.get("list3")
 
   # announce or provide details of our team meeting
   robot.respond /meeting\s*\b(.*)/i, (res) ->
@@ -30,16 +31,15 @@ module.exports = (robot) ->
 
   # provide details of our team mission
   robot.respond /mission/i, (res) ->
-    res.send "Our mission is to provide data, services and tools to positively impact the quality of Mozilla websites. " +
-      "https://wiki.mozilla.org/QA/Execution/Web_Testing/Mission"
+    res.send properties.get("mission")
 
   # provide details about webqabot's source code
   robot.respond /source/i, (res) ->
-    res.send "My details and code live at https://github.com/mozilla/webqabot/"
+    res.send properties.get("source")
 
   # provide a link to team info
   robot.respond /team/i, (res) ->
-    res.send "https://wiki.mozilla.org/QA/Execution/Web_Testing#Team_Members"
+    res.send properties.get("team")
 
   # provide details of our vidyo room
   robot.respond /vidyo/i, (res) ->

--- a/tests/test_webqa.coffee
+++ b/tests/test_webqa.coffee
@@ -1,0 +1,81 @@
+Helper = require 'hubot-test-helper'
+helper = new Helper('../scripts/webqa.coffee')
+chai = require 'chai'
+expect = chai.expect
+PropertiesReader = require 'properties-reader'
+properties = PropertiesReader('resources/responses.properties')
+util = require('util') 
+
+describe 'webqa script', ->    
+  hubotVidyoExpectedResponse = [
+        [ 'hubot', properties.get("vidyo1")]
+        [ 'hubot', properties.get("vidyo2")]
+        [ 'hubot', properties.get("vidyo3")]
+        [ 'hubot', properties.get("vidyo4")]
+      ]
+
+  beforeEach ->
+    @room = helper.createRoom()
+    
+  afterEach ->
+    @room.destroy()
+
+  context 'hubot responding to events', ->
+    it 'will respond to the announceMeeting event', ->
+      time =  properties.get("cronTime")
+      @room.robotEvent 'announceMeeting', time
+      expectedMeetingResponse = [
+        ['hubot', util.format(properties.get("time2"), time)]
+        ['hubot', properties.get("time3")]
+      ]
+      expectedMeetingResponse.push hubotVidyoExpectedResponse...
+      expect(@room.messages).to.eql expectedMeetingResponse
+
+  context 'hubot responding to user messages', ->
+    it 'will respond to meeting', ->
+      expectedMeetingResponse = [
+        ['shaggy', 'hubot meeting']
+        ['hubot', util.format(properties.get("time2"), properties.get("time1"))]
+        ['hubot', properties.get("time3")]
+      ]
+      expectedMeetingResponse.push hubotVidyoExpectedResponse...
+      @room.user.say('shaggy', 'hubot meeting').then =>
+        expect(@room.messages).to.eql expectedMeetingResponse
+
+    it 'will respond to list', ->
+      @room.user.say('scooby', 'hubot list').then =>
+        expect(@room.messages).to.eql [
+          ['scooby', 'hubot list']
+          ['hubot', properties.get("list1")]
+          ['hubot', properties.get("list2")]
+          ['hubot', properties.get("list3")]
+        ]
+    
+    it 'will respond to mission', ->
+      @room.user.say('fred', 'hubot mission').then =>
+        expect(@room.messages).to.eql [
+          ['fred', 'hubot mission']
+          ['hubot', properties.get("mission")]
+        ]
+
+    it 'will respond to source', ->
+      @room.user.say('barney', 'hubot source').then =>
+        expect(@room.messages).to.eql [
+          ['barney', 'hubot source']
+          ['hubot', properties.get("source")]
+        ]
+
+    it 'will respond to team', ->
+      @room.user.say('wilma', 'hubot team').then =>
+        expect(@room.messages).to.eql [
+          ['wilma', 'hubot team']
+          ['hubot', properties.get("team")]
+        ]
+
+    it 'will respond to vidyo', ->
+      expectedVidyoResult = [['betty', 'hubot vidyo']]
+      expectedVidyoResult.push hubotVidyoExpectedResponse...
+      @room.user.say('betty', 'hubot vidyo').then =>
+        expect(@room.messages).to.eql expectedVidyoResult
+
+  


### PR DESCRIPTION
Hi @bobsilverberg 

Here are the changes containing the unit tests for the webqabot. You will need to have mocha, chai and hubot-test-helper installed. Example:

```
 npm install mocha 
 npm install hubot-test-helper 
 npm install chai 
```

The following command will run the unit tests:
```
mocha --compilers "coffee:coffee-script/register" test/test_webqa.coffee
```

Thank you for the info about travisci.  I'll look into adding a .travis.yml to this pull request.  I don't have any specific questions yet.  I'm just figuring out what need needs to go into the script (at a minimum I guess I'll need to make sure the dependencies (mocha etc) are present and to run the command).

Thanks

Monica